### PR TITLE
Preventing bootstrap on non-api tests

### DIFF
--- a/src/DennisDigital/TermManagerExtension/Context/TermManagerContext.php
+++ b/src/DennisDigital/TermManagerExtension/Context/TermManagerContext.php
@@ -48,7 +48,7 @@ class TermManagerContext extends RawDrupalContext {
   private $setupDone;
 
   /**
-   * @BeforeScenario
+   * @BeforeScenario @api
    *
    * @param BeforeScenarioScope $scope
    */


### PR DESCRIPTION
Tagging Behat hook to prevent it running on non-api tests